### PR TITLE
Store Character Encoding pref as NSUInteger instead of int.

### DIFF
--- a/sources/NSTextField+iTerm.h
+++ b/sources/NSTextField+iTerm.h
@@ -17,5 +17,6 @@
 // Annoyingly, [field setIntValue:1234] places a stringValue of "1,234"
 // in field, which [field intValue] parses as "1", so use this instead.
 - (int)separatorTolerantIntValue;
+- (NSUInteger)separatorTolerantUIntValue;
 
 @end

--- a/sources/NSTextField+iTerm.m
+++ b/sources/NSTextField+iTerm.m
@@ -38,4 +38,10 @@
     }
 }
 
+- (NSUInteger)separatorTolerantUIntValue {
+    NSString *digits = [[self stringValue] stringByReplacingOccurrencesOfRegex:@"[^0-9]"
+                                                                    withString:@""];
+        return [digits unsignedIntegerValue];
+}
+
 @end

--- a/sources/PTYSession.m
+++ b/sources/PTYSession.m
@@ -1154,7 +1154,7 @@ static NSTimeInterval kMinimumPartialLineTriggerCheckInterval = 0.5;
             pwd = NSHomeDirectory();
         }
     }
-    isUTF8 = ([iTermProfilePreferences intForKey:KEY_CHARACTER_ENCODING inProfile:profile] == NSUTF8StringEncoding);
+    isUTF8 = ([iTermProfilePreferences uintForKey:KEY_CHARACTER_ENCODING inProfile:profile] == NSUTF8StringEncoding);
 
     [[[self tab] realParentWindow] setName:theName forSession:self];
 
@@ -2703,11 +2703,7 @@ static NSTimeInterval kMinimumPartialLineTriggerCheckInterval = 0.5;
                    nonAscii:[iTermProfilePreferences boolForKey:KEY_NONASCII_ANTI_ALIASED
                                                       inProfile:aDict]];
     
-    // Unfortunately, this preference has been saved as a 32-bit int for a while, although it should
-    // be an unsigned 64 bit. Luckily, 32 bits happens to be enough so far, since enabling 64-bit
-    // storage is in the profile prefs system is somewhat involved. For now, hack off the sign
-    // extension.
-    [self setEncodingFromSInt32:[iTermProfilePreferences intForKey:KEY_CHARACTER_ENCODING inProfile:aDict]];
+    [self setEncoding:[iTermProfilePreferences uintForKey:KEY_CHARACTER_ENCODING inProfile:aDict]];
     [self setTermVariable:[iTermProfilePreferences stringForKey:KEY_TERMINAL_TYPE inProfile:aDict]];
     [self setAntiIdleCode:[iTermProfilePreferences intForKey:KEY_IDLE_CODE inProfile:aDict]];
     [self setAntiIdle:[iTermProfilePreferences boolForKey:KEY_SEND_CODE_WHEN_IDLE inProfile:aDict]];
@@ -2991,13 +2987,6 @@ static NSTimeInterval kMinimumPartialLineTriggerCheckInterval = 0.5;
 - (NSStringEncoding)encoding
 {
     return [_terminal encoding];
-}
-
-// See note at call site about why this exists.
-- (void)setEncodingFromSInt32:(int)intEncoding {
-    NSStringEncoding encoding = intEncoding;
-    encoding &= 0xffffffff;
-    [self setEncoding:encoding];
 }
 
 - (void)setEncoding:(NSStringEncoding)encoding {

--- a/sources/PreferenceInfo.h
+++ b/sources/PreferenceInfo.h
@@ -12,8 +12,10 @@ typedef NS_ENUM(NSInteger, PreferenceInfoType) {
     kPreferenceInfoTypeCheckbox,
     kPreferenceInfoTypeInvertedCheckbox,  // true=checked, false=unchecked. Handy when inverting a checkbox's text, but the user defaults key can't be changed.
     kPreferenceInfoTypeIntegerTextField,
+    kPreferenceInfoTypeUnsignedIntegerTextField,
     kPreferenceInfoTypeStringTextField,
     kPreferenceInfoTypePopup,
+    kPreferenceInfoTypeUPopup,
     kPreferenceInfoTypeSlider,
     kPreferenceInfoTypeTokenField,
     kPreferenceInfoTypeMatrix,

--- a/sources/ProfilesTerminalPreferencesViewController.m
+++ b/sources/ProfilesTerminalPreferencesViewController.m
@@ -73,12 +73,9 @@
     [self populateEncodings];
     info = [self defineControl:_characterEncoding
                            key:KEY_CHARACTER_ENCODING
-                          type:kPreferenceInfoTypePopup];
+                          type:kPreferenceInfoTypeUPopup];
     info.onUpdate = ^BOOL() {
-        // Unfortunately, character encoding should have been stored as a NSUInteger all along :(
-        // See notes in PTYSession for more details.
-        NSInteger tag = [self intForKey:info.key];
-        tag &= 0xffffffff;
+        NSUInteger tag = [self uintForKey:info.key];
         [_characterEncoding selectItemWithTag:tag];
         return YES;
     };

--- a/sources/PseudoTerminal.m
+++ b/sources/PseudoTerminal.m
@@ -6857,7 +6857,7 @@ static NSString* TERMINAL_ARRANGEMENT_HIDING_TOOLBELT_SHOULD_RESIZE_WINDOW = @"H
             }
         }
         NSDictionary *env = [NSDictionary dictionaryWithObject: pwd forKey:@"PWD"];
-        isUTF8 = ([iTermProfilePreferences intForKey:KEY_CHARACTER_ENCODING inProfile:profile] == NSUTF8StringEncoding);
+        isUTF8 = ([iTermProfilePreferences uintForKey:KEY_CHARACTER_ENCODING inProfile:profile] == NSUTF8StringEncoding);
         [self setName:name forSession:aSession];
         // Start the command
         [self startProgram:cmd
@@ -7110,7 +7110,7 @@ static NSString* TERMINAL_ARRANGEMENT_HIDING_TOOLBELT_SHOULD_RESIZE_WINDOW = @"H
             pwd = NSHomeDirectory();
         }
         NSDictionary *env = [NSDictionary dictionaryWithObject: pwd forKey:@"PWD"];
-        BOOL isUTF8 = ([iTermProfilePreferences intForKey:KEY_CHARACTER_ENCODING inProfile:profile] == NSUTF8StringEncoding);
+        BOOL isUTF8 = ([iTermProfilePreferences uintForKey:KEY_CHARACTER_ENCODING inProfile:profile] == NSUTF8StringEncoding);
 
         [self setName:[name stringByPerformingSubstitutions:substitutions]
            forSession:aSession];

--- a/sources/ToolJobs.m
+++ b/sources/ToolJobs.m
@@ -93,6 +93,20 @@ static const CGFloat kMargin = 4;
     [self setToolTip:[NSString stringWithFormat:@"SIG%@ (%d)", signalNames[i], i]];
 }
 
+- (NSUInteger)uintValue {
+    NSUInteger x = [[self class] signalForName:[self stringValue]];
+    return x == -1 ? kDefaultSignal : x;
+}
+
+- (void)setUIntValue:(unsigned long)i {
+    NSArray *signalNames = [[self class] signalNames];
+    if (i <= 0 || i >= [signalNames count]) {
+        i = kDefaultSignal;
+    }
+    [self setStringValue:signalNames[i]];
+    [self setToolTip:[NSString stringWithFormat:@"SIG%@ (%lu)", signalNames[i], i]];
+}
+
 - (BOOL)isValid {
     return [[self class] signalForName:[self stringValue]] != -1;
 }

--- a/sources/iTermPreferences.h
+++ b/sources/iTermPreferences.h
@@ -153,6 +153,9 @@ extern NSString *const kPreferenceKeyShowFullscreenTabBar;
 + (int)intForKey:(NSString *)key;
 + (void)setInt:(int)value forKey:(NSString *)key;
 
++ (NSUInteger)uintForKey:(NSString *)key;
++ (void)setUInt:(NSUInteger)value forKey:(NSString *)key;
+
 + (double)floatForKey:(NSString *)key;
 + (void)setFloat:(double)value forKey:(NSString *)key;
 

--- a/sources/iTermPreferences.m
+++ b/sources/iTermPreferences.m
@@ -279,9 +279,13 @@ static NSMutableDictionary *gObservers;
     id defaultValue = [self defaultValueMap][key];
     switch (type) {
         case kPreferenceInfoTypeIntegerTextField:
+        case kPreferenceInfoTypeUnsignedIntegerTextField:
         case kPreferenceInfoTypePopup:
             return ([defaultValue isKindOfClass:[NSNumber class]] &&
                     [defaultValue doubleValue] == ceil([defaultValue doubleValue]));
+        case kPreferenceInfoTypeUPopup:
+            return ([defaultValue isKindOfClass:[NSNumber class]] &&
+                    [defaultValue unsignedLongValue] == ceil([defaultValue unsignedLongValue]));
         case kPreferenceInfoTypeCheckbox:
         case kPreferenceInfoTypeInvertedCheckbox:
             return ([defaultValue isKindOfClass:[NSNumber class]] &&
@@ -388,6 +392,14 @@ static NSMutableDictionary *gObservers;
 }
 
 + (void)setInt:(int)value forKey:(NSString *)key {
+    [self setObject:@(value) forKey:key];
+}
+
++ (NSUInteger)uintForKey:(NSString *)key {
+    return [(NSNumber *)[self objectForKey:key] unsignedIntegerValue];
+}
+
++ (void)setUInt:(NSUInteger)value forKey:(NSString *)key {
     [self setObject:@(value) forKey:key];
 }
 

--- a/sources/iTermPreferencesBaseViewController.h
+++ b/sources/iTermPreferencesBaseViewController.h
@@ -65,6 +65,9 @@
 - (int)intForKey:(NSString *)key;
 - (void)setInt:(int)value forKey:(NSString *)key;
 
+- (NSUInteger)uintForKey:(NSString *)key;
+- (void)setUInt:(NSUInteger)value forKey:(NSString *)key;
+
 - (double)floatForKey:(NSString *)key;
 - (void)setFloat:(double)value forKey:(NSString *)key;
 

--- a/sources/iTermProfilePreferences.h
+++ b/sources/iTermProfilePreferences.h
@@ -34,6 +34,12 @@ extern NSString *const kProfilePreferenceInitialDirectoryAdvancedValue;
      inProfile:(Profile *)profile
          model:(ProfileModel *)model;
 
++ (NSUInteger)uintForKey:(NSString *)key inProfile:(Profile *)profile;
++ (void)setUInt:(NSUInteger)value
+        forKey:(NSString *)key
+     inProfile:(Profile *)profile
+         model:(ProfileModel *)model;
+
 + (double)floatForKey:(NSString *)key inProfile:(Profile *)profile;
 + (void)setFloat:(double)value
           forKey:(NSString *)key

--- a/sources/iTermProfilePreferences.m
+++ b/sources/iTermProfilePreferences.m
@@ -46,6 +46,17 @@ NSString *const kProfilePreferenceInitialDirectoryAdvancedValue = @"Advanced";
     [self setObject:@(value) forKey:key inProfile:profile model:model];
 }
 
++ (NSUInteger)uintForKey:(NSString *)key inProfile:(Profile *)profile {
+    return [[self objectForKey:key inProfile:profile] unsignedIntegerValue];
+}
+
++ (void)setUInt:(NSUInteger)value
+        forKey:(NSString *)key
+     inProfile:(Profile *)profile
+         model:(ProfileModel *)model {
+    [self setObject:@(value) forKey:key inProfile:profile model:model];
+}
+
 + (double)floatForKey:(NSString *)key inProfile:(Profile *)profile {
     return [[self objectForKey:key inProfile:profile] doubleValue];
 }
@@ -77,9 +88,13 @@ NSString *const kProfilePreferenceInitialDirectoryAdvancedValue = @"Advanced";
     id defaultValue = [self defaultValueMap][key];
     switch (type) {
         case kPreferenceInfoTypeIntegerTextField:
+        case kPreferenceInfoTypeUnsignedIntegerTextField:
         case kPreferenceInfoTypePopup:
             return ([defaultValue isKindOfClass:[NSNumber class]] &&
                     [defaultValue doubleValue] == ceil([defaultValue doubleValue]));
+        case kPreferenceInfoTypeUPopup:
+            return ([defaultValue isKindOfClass:[NSNumber class]] &&
+                    [defaultValue unsignedLongValue] == ceil([defaultValue unsignedLongValue]));
         case kPreferenceInfoTypeCheckbox:
         case kPreferenceInfoTypeInvertedCheckbox:
             return ([defaultValue isKindOfClass:[NSNumber class]] &&

--- a/sources/iTermProfilePreferencesBaseViewController.m
+++ b/sources/iTermProfilePreferencesBaseViewController.m
@@ -44,6 +44,17 @@
     [iTermProfilePreferences setInt:value forKey:key inProfile:profile model:model];
 }
 
+- (NSUInteger)uintForKey:(NSString *)key {
+    Profile *profile = [_delegate profilePreferencesCurrentProfile];
+    return [iTermProfilePreferences uintForKey:key inProfile:profile];
+}
+
+- (void)setUInt:(NSUInteger)value forKey:(NSString *)key {
+    Profile *profile = [_delegate profilePreferencesCurrentProfile];
+    ProfileModel *model = [_delegate profilePreferencesCurrentModel];
+    [iTermProfilePreferences setUInt:value forKey:key inProfile:profile model:model];
+}
+
 - (double)floatForKey:(NSString *)key {
     Profile *profile = [_delegate profilePreferencesCurrentProfile];
     return [iTermProfilePreferences floatForKey:key inProfile:profile];


### PR DESCRIPTION
Fixes: https://gitlab.com/gnachman/iterm2/issues/4105

PTYSession.m (before):
// Unfortunately, this preference has been saved as a 32-bit int for a while, although it should
// be an unsigned 64 bit. Luckily, 32 bits happens to be enough so far, since enabling 64-bit
// storage is in the profile prefs system is somewhat involved. For now, hack off the sign
// extension.
[self setEncodingFromSInt32:[iTermProfilePreferences intForKey:KEY_CHARACTER_ENCODING inProfile:aDict]];
[...]
// See note at call site about why this exists.
- (void)setEncodingFromSInt32:(int)intEncoding {
    NSStringEncoding encoding = intEncoding;
    encoding &= 0xffffffff;
    [self setEncoding:encoding];
}

ProfilesTerminalPreferencesViewController.m (before):
// Unfortunately, character encoding should have been stored as a NSUInteger all along :(
// See notes in PTYSession for more details.
NSInteger tag = [self intForKey:info.key];
tag &= 0xffffffff;
[_characterEncoding selectItemWithTag:tag];